### PR TITLE
Fix wrong condition for config.useRegions

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionFlagsListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionFlagsListener.java
@@ -81,7 +81,7 @@ public class RegionFlagsListener extends AbstractListener {
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onBreakBlock(final BreakBlockEvent event) {
         WorldConfiguration config = getWorldConfig(event.getWorld());
-        if (config.useRegions) return; // Region support disabled
+        if (!config.useRegions) return; // Region support disabled
         if (config.isEventDisabled(event.getEventName())) return;
 
         RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
@@ -119,7 +119,7 @@ public class RegionFlagsListener extends AbstractListener {
         Entity entity = event.getEntity();
         World world = entity.getWorld();
         WorldConfiguration config = getWorldConfig(world);
-        if (config.useRegions) return; // Region support disabled
+        if (!config.useRegions) return; // Region support disabled
         if (config.isEventDisabled(event.getEventName())) return;
 
         if (Entities.isNPC(entity)) return;


### PR DESCRIPTION
The previous implementation used !isRegionSupportEnabled, a not was lost when re-writing this I guess?