### PR TITLE
Handle TNT explosions properly outside regions

### DIFF
--- a/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -485,10 +485,18 @@ public class WorldGuardEntityListener extends AbstractListener {
                 return;
             }
             if (wcfg.useRegions) {
-                event.blockList().removeIf(block ->
-                    !WorldGuard.getInstance().getPlatform().getRegionContainer()
-                            .createQuery()
-                            .testState(BukkitAdapter.adapt(block.getLocation()), null, Flags.TNT));
+                RegionQuery query = WorldGuard.getInstance()
+                        .getPlatform()
+                        .getRegionContainer()
+                        .createQuery();
+
+                event.blockList().removeIf(block -> {
+                    ApplicableRegionSet regions = query.getApplicableRegions(
+                            BukkitAdapter.adapt(block.getLocation())
+                    );
+
+                    return regions.size() > 0 && !regions.testState(null, Flags.TNT);
+                });
             }
             return;
         }


### PR DESCRIPTION
With this change, TNT no longer requires the `tnt` flag to be explicitly allowed in the global region. Locations with no applicable regions now behave as if `tnt` were allowed by default.

This preserves existing region flag behavior, as the `tnt` flag must still be explicitly defined inside regions.